### PR TITLE
CIF number for spanish companies 

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -194,6 +194,10 @@
     created: '',
     transactionCount: 0,
     initiatorName: '',
+    /**
+     * Used by spanish companies it's mandatory for SEPA in spain.
+     */
+    cifNumber: '',
     controlSum: 0,
     batchBooking: false,
     grouping: 'MIXD',
@@ -224,7 +228,12 @@
         r(grpHdr, 'Grpg', this.grouping);
       }
 
-      r(grpHdr, 'InitgPty', 'Nm', this.initiatorName);
+      var n = createXMLHelper(doc, true, false);
+      var initgPty = n(grpHdr, 'InitgPty');
+      r(initgPty, 'Nm', this.initiatorName);
+      if (this.cifNumber) {
+        r(initgPty, 'Id', 'OrgId', 'Othr', 'Id', this.cifNumber);
+      }
 
       return grpHdr;
     },


### PR DESCRIPTION
Spanish companies do not follow the SEPA norm they use the othr id field to pass CIF number (some kind of TVA number)